### PR TITLE
Update workflow release triggers and manifest generation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,10 +2,12 @@ name: Build font and specimen
 
 on:
   push:
+    branches:
+      - main
+      - release
+      - release/**
   pull_request:
   workflow_dispatch:
-  release:
-    types: [published]
 
 permissions:
   contents: write
@@ -79,17 +81,10 @@ jobs:
         else
           echo "No TTF files found to copy into out/ttf."
         fi
-        python - <<'PY'
-import json
-from pathlib import Path
-
-root = Path("out")
-manifest = [str(path.relative_to(root)) for path in (root / "ttf").rglob("*.ttf")]
-(root / "ttf_manifest.json").write_text(json.dumps(manifest, indent=2))
-PY
+        python scripts/generate-ttf-manifest.py
         cp scripts/index.html out/index.html
     - name: Collect deployment assets
-      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+      if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/') }}
       uses: actions/upload-pages-artifact@v3
       with:
         path: ./out
@@ -106,7 +101,7 @@ PY
 
   deploy:
     name: Deploy results to GitHub Pages
-    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/') }}
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -130,7 +125,7 @@ PY
 
   release:
     name: Release bundle
-    if: contains(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/release' || startsWith(github.ref, 'refs/heads/release/')
     needs:
       - build
       - deploy

--- a/scripts/generate-ttf-manifest.py
+++ b/scripts/generate-ttf-manifest.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import json
+from pathlib import Path
+
+
+def main() -> None:
+    root = Path("out")
+    manifest = [str(path.relative_to(root)) for path in (root / "ttf").rglob("*.ttf")]
+    (root / "ttf_manifest.json").write_text(json.dumps(manifest, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace the inline Python manifest generation with a reusable script
- enable release flows to run when pushing to release branches and include them in deployment steps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928d1f172ec8329bb9c7b9893e865d6)